### PR TITLE
Coexist with other WS handlers on same server

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,9 +20,7 @@ const createEndpoint = ({server, port, logger}) => {
     const parsed = parseurl(req);
     const client = router.route(req);
     if (!client) {
-      logger.info(`No client found for path: ${parsed.path}`);
-      socket.write('HTTP/1.1 404 Not Found\r\n\r\n');
-      socket.destroy();
+      logger.debug(`No client found for path: ${parsed.path}`);
       return;
     }
     wss.handleUpgrade(req, socket, head, (ws) => {


### PR DESCRIPTION
This PR patches the upgrade event handler registered by the server to do nothing if
we have no endpoint for the request, instead of actively rejecting the socket.

This is needed if we want to run other websocket services on different paths hooked
off the same HTTP server. In these circumstances both services will register
an upgrade handler, and silently drop through to the next handler if they aren't interested
in the endpoint.

If none of the services are interested in the path, the upgrade transaction should be 404'd
by the default handler, but crucially this handler won't terminate the chain early by closing the socket.