### PR TITLE
Dont generate a 404 for unknown paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,8 +68,6 @@ const createEndpoint = ({
     const client = router.route(req);
     if (!client) {
       logger.debug(`No client found for path: ${parsed.pathname}`);
-      res.writeHead(404, { 'Content-Type': 'text/plain' });
-      res.end('404 Not Found');
       return;
     }
     req.client = client;


### PR DESCRIPTION
The WS upgrade handler can't coexist with other WS servers on the same httpServer as it  sets a 404 response header on any path it isn't intrested in.
If it just silently ignores and falls through then other handlers can process the upgrade if they wish to.
See also PR #5 which was somewhat related (same problem, different 404)
